### PR TITLE
Added dependencies for workshop

### DIFF
--- a/dockerfiles/Dockerfile.scipy
+++ b/dockerfiles/Dockerfile.scipy
@@ -35,3 +35,15 @@ RUN conda install --quiet --yes \
     rm -rf /home/$NB_USER/.node-gyp && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
+
+RUN mkdir -p /tmp/nexuscli && \
+    cd /tmp/nexuscli && \
+    git init && \
+    git remote add -f origin https://github.com/apache/incubator-sdap-nexus && \
+    git config core.sparseCheckout true && \
+    echo "client" >> .git/info/sparse-checkout && \
+    git pull origin master && \
+    cd client && \
+    conda install shapely && \
+    python setup.py install && \
+    pip install -r requirements.txt


### PR DESCRIPTION
@kmaull-ucar I added the steps to install our dependencies as you suggested. However when I try to build the image it fails this install:

`conda install -y -q -c conda-forge hone`

With this error:

> PackagesNotFoundError: The following packages are not available from current channels:
> 
>   - hone
> 
> Current channels:
> 
>  - https://conda.anaconda.org/conda-forge/linux-64
>  - https://conda.anaconda.org/conda-forge/noarch
>   - https://repo.anaconda.com/pkgs/main/linux-64
>   - https://repo.anaconda.com/pkgs/main/noarch
>   - https://repo.anaconda.com/pkgs/free/linux-64
>   - https://repo.anaconda.com/pkgs/free/noarch
>   - https://repo.anaconda.com/pkgs/r/linux-64
>   - https://repo.anaconda.com/pkgs/r/noarch
>   - https://repo.anaconda.com/pkgs/pro/linux-64
>   - https://repo.anaconda.com/pkgs/pro/noarch
> 
> To search for alternate channels that may provide the conda package you're
> looking for, navigate to
> 
>     https://anaconda.org
> 
> and use the search bar at the top of the page.

But if I just build the image with my instructions it works. Maybe you can try it?